### PR TITLE
Fix for Universal Ctags

### DIFF
--- a/autoload/wordpress.vim
+++ b/autoload/wordpress.vim
@@ -1431,6 +1431,7 @@ endfunction
 
 function! s:CTagsBuilder_run(cmd) dict
   let result = system(a:cmd)
+  echom result
   return [v:shell_error, result]
 endfunction
 
@@ -1546,20 +1547,21 @@ function! s:CTagsCommandBuilder_build() dict
   let cmd = self.get_executable()
   let cmd .= " -R"
   let cmd .= " -f " . shellescape(self.get_tags_name())
-  let cmd .= " --tag-relative"
-  let re = self.to_invocation_regex('action', 'a', 'do_action')
+  let cmd .= " --tag-relative=yes"
+  let re = self.to_invocation_regex('action', 'A', 'do_action')
   let cmd .= " --regex-PHP=" . shellescape(re)
-  let re = self.to_listener_regex('alistener', 'l', 'add_action')
+  let re = self.to_listener_regex('alistener', 'L', 'add_action')
   let cmd .= " --regex-PHP=" . shellescape(re)
-  let re = self.to_invocation_regex('filter', 'r', 'apply_filters')
+  let re = self.to_invocation_regex('filter', 'R', 'apply_filters')
   let cmd .= " --regex-PHP=" . shellescape(re)
-  let re = self.to_listener_regex('flistener', 'e', 'add_filter')
+  let re = self.to_listener_regex('flistener', 'E', 'add_filter')
   let cmd .= " --regex-PHP=" . shellescape(re)
   let dirs = self.get_exclude_dirs()
   for dir in dirs
     let cmd .= " --exclude=" . dir
   endfor
   let cmd .= " ."
+  "echom cmd
   return cmd
 endfunction
 
@@ -1572,6 +1574,9 @@ function! s:CTagsCommandBuilder_get_exclude_dirs() dict
   call add(dirs, 'build')
   call add(dirs, 'dist')
   call add(dirs, 'vendor')
+  call add(dirs, '"*.js"')
+  call add(dirs, '"*.css"')
+  call add(dirs, '"*.scss"')
   return dirs
 endfunction
 
@@ -1649,7 +1654,7 @@ function! s:CTagsCommandBuilder_has_exuberant_executable() dict
     return self.exuberant_found
   endif
   let ctags_version = system(self.get_executable() . ' --version')
-  if ctags_version =~# 'Exuberant Ctags'
+  if ctags_version =~# '\(Exuberant\|Universal\) Ctags'
     let self.exuberant_found = 1
   else
     let self.exuberant_found = 0

--- a/lib/wordpress/ctags/ctags_command_builder.riml
+++ b/lib/wordpress/ctags/ctags_command_builder.riml
@@ -10,18 +10,18 @@ class CTagsCommandBuilder
     cmd   = self.get_executable()
     cmd .= " -R"
     cmd .= " -f #{shellescape(self.get_tags_name())}"
-    cmd .= " --tag-relative"
+    cmd .= " --tag-relative=yes"
 
-    re   = self.to_invocation_regex('action', 'a', 'do_action')
+    re   = self.to_invocation_regex('action', 'A', 'do_action')
     cmd .= " --regex-PHP=#{shellescape(re)}"
 
-    re   = self.to_listener_regex('alistener', 'l', 'add_action')
+    re   = self.to_listener_regex('alistener', 'L', 'add_action')
     cmd .= " --regex-PHP=#{shellescape(re)}"
 
-    re   = self.to_invocation_regex('filter', 'r', 'apply_filters')
+    re   = self.to_invocation_regex('filter', 'R', 'apply_filters')
     cmd .= " --regex-PHP=#{shellescape(re)}"
 
-    re   = self.to_listener_regex('flistener', 'e', 'add_filter')
+    re   = self.to_listener_regex('flistener', 'E', 'add_filter')
     cmd .= " --regex-PHP=#{shellescape(re)}"
 
     " exclude files to fix #16
@@ -46,6 +46,9 @@ class CTagsCommandBuilder
     add(dirs, 'build')
     add(dirs, 'dist')
     add(dirs, 'vendor')
+    add(dirs, '"*.js"')
+    add(dirs, '"*.css"')
+    add(dirs, '"*.scss"')
 
     return dirs
   end
@@ -122,7 +125,7 @@ class CTagsCommandBuilder
 
     ctags_version = system(self.get_executable() . ' --version')
 
-    if ctags_version =~ 'Exuberant Ctags'
+    if ctags_version =~ '\(Exuberant\|Universal\) Ctags'
       self.exuberant_found = true
     else
       self.exuberant_found = false


### PR DESCRIPTION
Exuberant Ctags is no longer maintained, and the project has been continued in spirit by [Universal Ctags](https://github.com/universal-ctags). This plugin was looking specifically for Exuberant, which I changed. 

I also fixed some errors that prevent Universal Ctags from running, and play well between both versions of Ctags.

